### PR TITLE
Adding a tools page to the website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,7 @@ github_username:  webarkit
 author: Walter Perdan
 # google_analytics: UA-00000000-0
 favicon: /favicon.ico
+theme_color: '#1E2A78'
 
 # Pagination settings
 paginate: 6

--- a/_data/footer_menu.yml
+++ b/_data/footer_menu.yml
@@ -2,6 +2,8 @@
   link: /
 - name: Blog
   link: /blog/
+- name: Tools
+  link: /tools/
 - name: Examples
   link: /examples
 - name: Project

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,5 +1,7 @@
 - name: Blog
   link: /blog/
+- name: Tools
+  link: /tools/
 - name: Examples
   link: /examples
 - name: Project

--- a/_includes/head-scripts.html
+++ b/_includes/head-scripts.html
@@ -1,4 +1,3 @@
-<meta name="theme-color" content="#1E2A78">
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-S3HVPJX68V"></script>
 <script>

--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-<h1 class="title">{{ page.header_tile}}</h1>
+<h1 class="title">{{ page.header_title}}</h1>
   {{ content }}
 
 <div class="box">

--- a/contact.md
+++ b/contact.md
@@ -2,7 +2,7 @@
 layout: contact
 title: The WebAR Kit contact page
 subtitle: Contact us for more infos...
-header_tile: Contact us
+header_title: Contact us
 description: In this page you can contact us for more informations about our WebAR project, and if you want to join the team. Collaborations are very welcome!
 image: ./resources/webarkit-logo-social.jpg
 permalink: /contact/

--- a/tools/index.html
+++ b/tools/index.html
@@ -1,0 +1,9 @@
+---
+layout: page
+title: The WebAR Kit tools page
+subtitle: A set of useful tools for WebAR
+#header_tile: WebARkit tools
+description: A set of tools for helping developers and creatives to assit in AR content creation.
+image: ./resources/webarkit-logo-social.jpg
+permalink: /tools/
+---


### PR DESCRIPTION
This PR add a **Tools** page and a sub-page **NFT_Marker_Creator** page to create NFT markers. 
Set of changes:
- Theme update; `theme_color` now is an option to set in the `_config.yml`.
- Small typos fixes